### PR TITLE
Add release registration step to gha queue process

### DIFF
--- a/gha_cron.php
+++ b/gha_cron.php
@@ -152,6 +152,7 @@ function processQueueFile($filepath) {
     $queue_url = SITE_URL . 'github_artifact.php';
     $headers = array();
     $unzip = ($data['unzip']) ? '1' : '0';
+    $release = ($data['release']) ? '1' : '0';
     
     if (isset($data['id'])) {
         $id = $data['id'];
@@ -166,7 +167,7 @@ function processQueueFile($filepath) {
         $headers[] = 'Max-Downloads: ' . strval( $data['maxdls'] );
     }
     
-    $url = $queue_url . '?id=' . strval($id) . '&unzip=' . $unzip;
+    $url = $queue_url . '?id=' . strval($id) . '&unzip=' . $unzip . '&release=' . $release;
     
     if ( processSnapshotFetch( $url, $headers ) ) {
         unlink($filepath);

--- a/gha_queue.php
+++ b/gha_queue.php
@@ -108,7 +108,6 @@ if (isset($_SERVER['HTTP_MAX_DOWNLOADS'])) {
     }
 }
 
-
 $artifact_data = array(
     'name' => $artifact_name,
     'unzip' => $unzip,
@@ -123,6 +122,11 @@ if ($maxdays != 0) {
 }
 if ($maxdls != 0) {
     $artifact_data['maxdls'] = $maxdls;
+}
+
+// Ensure that the artifact being queued is marked as a release in the output json
+if ( isset($_REQUEST['release']) ) {
+    $artifact_data['release'] = true;
 }
 
 $queue_json = json_encode($artifact_data);


### PR DESCRIPTION
This adds the functionality of registering a release with the wp-downloadmanager and dblsqd for release builds. This is needed because we can no longer use whitelisted IP's from the old Appveyor or Travis CI servers because the Windows builds are now being run on GitHub which have a large range of IPs.

A couple defines need to be set in the config.php as secrets:
MUDLET_DEPLOY_PATH - This is the target path where the installer is copied to, formerly by SCP, now can be just CP:
$cpCommand = "cp files/.$basename ".MUDLET_DEPLOY_PATH;

X_WP_DOWNLOAD_TOKEN - I assume this is the auth token for the wp-downloadmanager?