### PR TITLE
Show multiple flavours per OS type

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -43,6 +43,19 @@ if [ ! -f /workspace/ip_list ]; then
     echo "ip_list created."
 fi
 
+# Add local development IPs to ip_list if not already present
+if ! grep -q "127.0.0.1" /workspace/ip_list; then
+    echo "Adding local development IPs to ip_list..."
+    cat >> /workspace/ip_list << 'IPLIST'
+
+# Local Development IPs
+127.0.0.1	1	# Localhost
+::1	1	# IPv6 localhost
+172.18.0.0/16	1	# Docker network range
+IPLIST
+    echo "Local development IPs added to ip_list."
+fi
+
 # Create .htaccess from example if it doesn't exist and example exists
 if [ ! -f /workspace/.htaccess ]; then
     if [ -f /workspace/.htaccess.example ]; then
@@ -56,6 +69,61 @@ if [ ! -f /workspace/.htaccess ]; then
     else
         echo "Notice: .htaccess.example not found; skipping .htaccess creation."
     fi
+fi
+
+# Configure Apache for PUT requests and RewriteMap
+echo "Configuring Apache for PUT requests and RewriteMap..."
+
+# Enable required Apache modules
+if command -v a2enmod >/dev/null 2>&1; then
+    a2enmod actions 2>/dev/null || echo "actions module already enabled or unavailable"
+    a2enmod rewrite 2>/dev/null || echo "rewrite module already enabled or unavailable"
+fi
+
+# Update Apache VirtualHost configuration
+if [ -f /etc/apache2/sites-enabled/000-default.conf ]; then
+    echo "Updating Apache VirtualHost configuration..."
+    cat > /etc/apache2/sites-enabled/000-default.conf << 'APACHECONF'
+<VirtualHost *:80>
+        ServerAdmin webmaster@localhost
+        DocumentRoot /workspace
+
+        # RewriteMap for IP allowlist
+        RewriteMap allowed "txt:/workspace/ip_list"
+
+        # Handle PUT requests
+        Script PUT /workspace/put.php
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        <Directory /workspace>
+            Options -Indexes +FollowSymLinks
+            AllowOverride All
+            Require all granted
+            
+            # Enable PUT method in directory context
+            <Limit GET POST HEAD PUT OPTIONS>
+                Require all granted
+            </Limit>
+            <LimitExcept GET POST HEAD PUT OPTIONS>
+                Require all denied
+            </LimitExcept>
+        </Directory>
+</VirtualHost>
+APACHECONF
+    
+    # Test Apache configuration
+    if apachectl configtest 2>/dev/null; then
+        echo "Apache configuration is valid."
+        # Reload Apache to apply changes
+        apachectl graceful 2>/dev/null || service apache2 reload 2>/dev/null || echo "Warning: Could not reload Apache."
+        echo "Apache reloaded with new configuration."
+    else
+        echo "Warning: Apache configuration test failed. Please check manually."
+    fi
+else
+    echo "Notice: Apache VirtualHost configuration not found at expected location."
 fi
 
 # Wait for MySQL to be ready
@@ -92,8 +160,16 @@ echo "  Database: ci_snapshots"
 echo "  User: snapshots"
 echo "  Password: snapshots123"
 echo ""
+echo "Apache Configuration:"
+echo "  - PUT method enabled"
+echo "  - RewriteMap configured for IP allowlist"
+echo "  - Local IPs (127.0.0.1, ::1, Docker network) added to ip_list"
+echo ""
 echo "To initialize the database, visit:"
 echo "  http://localhost:8080/index.php"
+echo ""
+echo "To test file uploads:"
+echo "  curl --upload-file ./file.zip http://localhost:80/"
 echo ""
 echo "The application will automatically create required tables on first access."
 echo ""

--- a/index.php
+++ b/index.php
@@ -134,11 +134,7 @@ if (isset($_GET['dl'])) {
                         '<span class="filesize">' . _('DL #') . '</span>' .
                         '<span class="filegitlinks">' . _('Github') . '</span>' .
                     "</span></li>\n";
-        $latest_branch_snaps = array(
-            'windows' => null,
-            'linux'   => null,
-            'macos'   => null,
-        );
+        $latest_branch_snaps = [];
         $branch_names        = array( 'pull-request', 'branch' ); // defaults needed for client-side js.
         $branch_options      = '';
 
@@ -170,7 +166,7 @@ if (isset($_GET['dl'])) {
 
             // should probably start pushing explicit data to the DB instead of doing this regex stuff
             // but that would be more complicated in CI...
-            preg_match('/(?:-PR([0-9]+))?-([a-f0-9]{5,9})[\.-]{1}/i', $fname, $m);
+            preg_match('/(?:-PR([0-9]+))?-([a-f0-9]{5,9})[\.-]{1}([^.]+)/i', $fname, $m);
             preg_match('/\d+(?:\.\d+)+-(ptb)-(?:PR\d+-|\d+-)?/i', $fname, $bm);
 
             // Build? Branch?  The regex pulls exact match but this code is extensible.
@@ -188,7 +184,7 @@ if (isset($_GET['dl'])) {
 
             $source_class = 'branch ' . $branch_class;
             $gitLinks     = $PR_ID = $Commit_ID = '';
-            if (count($m) == 3) {
+            if (count($m) == 4) {
                 if (! empty($m[1])) {
                     $source_class = 'pull-request ' . $branch_class;
                     $git_url = 'https://github.com/Mudlet/Mudlet/pull/' . $m[1];
@@ -202,7 +198,7 @@ if (isset($_GET['dl'])) {
                     $Commit_ID = '<a href="' . $git_url . '" title="' . $git_ttl . '">' .
                                  '<i class="far fa-code-commit"></i></a>';
                 }
-            } elseif (count($m) == 2) {
+            } elseif (count($m) == 3) {
                 if (! empty($m[2])) {
                     $git_url = 'https://github.com/Mudlet/Mudlet/commit/' . $m[2];
                     $git_ttl = _('View Commit on Github.com');
@@ -236,6 +232,8 @@ if (isset($_GET['dl'])) {
                 $platform_type = 'macos';
             }
 
+            $flavour_type = $m[3];
+
             $item_classes = implode(' ', array( $platform_type, $source_class ));
 
             $item_link = '<a class="filename" href="' . $url . '" rel="nofollow">' . $platform_icon . $fname . '</a>';
@@ -262,18 +260,22 @@ if (isset($_GET['dl'])) {
             // if ( strpos($source_class, 'branch') !== false && (empty($inputSource) ||
             //      (strpos($source_class, $inputSource) !== false && !empty($inputSource))) ) {
             if (strpos($source_class, 'branch') !== false && strpos($source_class, 'ptb') !== false) {
-                if ($latest_branch_snaps['windows'] == null && $platform_type == 'windows') {
-                    $latest_branch_snaps['windows'] = '<span class="windows"><label>Windows:</label> ' . $item_link .
+                $key_name = $platform_type . '-' . $flavour_type;
+                if(array_key_exists($key_name, $latest_branch_snaps)){
+                    continue;
+                }
+                if ($platform_type == 'windows') {
+                    $latest_branch_snaps[$key_name] = '<span class="windows"><label>Windows (' . $flavour_type . '):</label> ' . $item_link .
                                                       '</span>';
                 }
 
-                if ($latest_branch_snaps['linux'] == null && $platform_type == 'linux') {
-                    $latest_branch_snaps['linux'] = '<span class="linux"><label>Linux:</label> ' . $item_link .
+                if ($platform_type == 'linux') {
+                    $latest_branch_snaps[$key_name] = '<span class="linux"><label>Linux (' . $flavour_type . '):</label> ' . $item_link .
                                                     '</span>';
                 }
 
-                if ($latest_branch_snaps['macos'] == null && $platform_type == 'macos') {
-                    $latest_branch_snaps['macos'] = '<span class="macos"><label>Mac OS X:</label> ' . $item_link .
+                if ($platform_type == 'macos') {
+                    $latest_branch_snaps[$key_name] = '<span class="macos"><label>Mac OS X (' . $flavour_type . '):</label> ' . $item_link .
                                                     '</span>';
                 }
             }

--- a/tpl/index.tpl.html
+++ b/tpl/index.tpl.html
@@ -194,7 +194,7 @@ footer a {
   display: inline-block;
 }
 .latest-branch-files label {
-  width: 100px;
+  width: 200px;
   text-align: right;
   margin-right: 6px;
   display: inline-block;


### PR DESCRIPTION
This pull request enhances the logic for displaying latest branch snapshots by platform and flavour in the application and introduces improvements to the local development environment setup.

This is done by interpreting the filename part after the commit hash as a OS flavour.

**Snapshot display logic:**

* In `index.php`, the regex for parsing snapshot filenames is updated to extract a new "flavour" field (e.g., distinguishing between different build types), and the logic for tracking latest branch snapshots now uses a combination key of platform and flavour, allowing multiple flavours per platform to be shown. [[1]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0L173-R169) [[2]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0R235-R236) [[3]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0L265-R278)
* The label width for latest branch files in `tpl/index.tpl.html` is increased to accommodate longer labels that now include the flavour information.

**Development environment setup:**

* The `.devcontainer/setup.sh` script now appends local development IPs (including `127.0.0.1`, `::1`, and Docker network range) to the `ip_list` for easier local testing and access control.
* Apache is automatically configured to support PUT requests, enable required modules, and use a `RewriteMap` for IP allowlisting based on the updated `ip_list`. The script also validates and reloads the Apache configuration.
* The setup script prints clearer instructions about Apache configuration, enabled PUT method, and how to test file uploads with `curl`.

These changes make the development environment easier to use locally.