### PR TITLE
Allow companion .sha256 files in artifact ZIPs

### DIFF
--- a/github_artifact.php
+++ b/github_artifact.php
@@ -107,7 +107,8 @@ if ( isset($jdata['archive_download_url']) ) {
 }
 
 
-// if we unzip, we must have only one file in the ZIP - exe, tar, etc.
+// if we unzip, we extract the main file from the ZIP - exe, tar, etc.
+// Companion files like .sha256 checksums are also extracted alongside it.
 // if we don't unzip, we need to build the artifact name using JSON data and .zip extension.
 if ($unzip) {
     $zip = new ZipArchive();
@@ -119,16 +120,30 @@ if ($unzip) {
         ExitFailedRequest('Artifact archive failed to open');
     }
 
-    if ( $zip->numFiles > 1 ) {
-        $nfiles = $zip->numFiles;
-        
-        @$zip->close();
-        @unlink($dl_tmpname);
-        ExitFailedRequest('Artifact archive contains more than 1 file - ' . strval($nfiles) );
+    // Find the main artifact file (not a companion like .sha256)
+    $artifact_filename = null;
+    $companion_files = array();
+    for ($i = 0; $i < $zip->numFiles; $i++) {
+        $fname = $zip->statIndex($i)['name'];
+        if (preg_match('/\.sha256$/', $fname)) {
+            $companion_files[] = $fname;
+        } else {
+            if ($artifact_filename !== null) {
+                @$zip->close();
+                @unlink($dl_tmpname);
+                ExitFailedRequest('Artifact archive contains multiple main files - ' . strval($zip->numFiles));
+            }
+            $artifact_filename = $fname;
+        }
     }
 
-    $fstat = $zip->statIndex( 0 );
-    $artifact_filename = $fstat['name'];
+    if ($artifact_filename === null) {
+        @$zip->close();
+        @unlink($dl_tmpname);
+        ExitFailedRequest('Artifact archive contains no main file');
+    }
+
+    $fstat = $zip->statIndex($zip->locateName($artifact_filename));
 
     if ( strpos($artifact_filename, '/') !== false || strpos($artifact_filename, '\\') !== false ) {
         @$zip->close();
@@ -139,8 +154,12 @@ if ($unzip) {
     $artifact_tmpname = dirname($dl_tmpname) . DIRECTORY_SEPARATOR . $artifact_filename;
     $ext_dir = dirname( $dl_tmpname );
 
-    // extraction should result in a path matching that of $artifact_tmpname
+    // Extract the main artifact file
     $exs = $zip->extractTo($ext_dir, array($artifact_filename));
+    // Also extract companion files (.sha256 checksums) alongside it
+    if (!empty($companion_files)) {
+        $zip->extractTo($ext_dir, $companion_files);
+    }
     $zip->close();
     @unlink($dl_tmpname);
 
@@ -199,6 +218,17 @@ $snapshot_path = $snapshot_ids[0];
 $snapshot_url = $snapshot_ids[1];
 $snapshot_uid = $snapshot_ids[2];
 if (rename($dl_tmpname, $snapshot_path)) {
+    // Move companion files (.sha256 checksums) alongside the main artifact
+    if (isset($companion_files) && !empty($companion_files)) {
+        foreach ($companion_files as $cfile) {
+            $cfile_tmp = $ext_dir . DIRECTORY_SEPARATOR . $cfile;
+            if (file_exists($cfile_tmp)) {
+                $cfile_dest = $ScriptPath . '/' . UPLOAD_DIR . $snapshot_uid . '_' . $cfile;
+                rename($cfile_tmp, $cfile_dest);
+            }
+        }
+    }
+
     $maxdays = DEFAULT_FILE_LIFETIME_DAYS;
     if (isset($_SERVER['HTTP_MAX_DAYS'])) {
         if (preg_match('/^[0-9]+$/i', $_SERVER['HTTP_MAX_DAYS']) === 1) {
@@ -211,10 +241,10 @@ if (rename($dl_tmpname, $snapshot_path)) {
             $maxdl = intval($_SERVER['HTTP_MAX_DOWNLOADS']);
         }
     }
-    
+
     echo($snapshot_url);
     echo("\n");
-    
+
     AddNewSnapshot($basename, $snapshot_uid, $maxdays, $maxdl);
     AddUploadLogRecord($snapshot_path);
 } else {

--- a/index.php
+++ b/index.php
@@ -238,7 +238,23 @@ if (isset($_GET['dl'])) {
 
             $item_link = '<a class="filename" href="' . $url . '" rel="nofollow">' . $platform_icon . $fname . '</a>';
 
-            $item = $item_link . '<span class="fileinfo">' .
+            // Check for companion .sha256 file
+            $sha256_html = '';
+            $sha256_filepath = $filepath . '.sha256';
+            if (is_file($sha256_filepath) && is_readable($sha256_filepath)) {
+                $sha256_content = trim(file_get_contents($sha256_filepath));
+                // sha256sum output format: "hash  filename" - extract just the hash
+                $sha256_parts = preg_split('/\s+/', $sha256_content, 2);
+                if (!empty($sha256_parts[0]) && preg_match('/^[a-f0-9]{64}$/i', $sha256_parts[0])) {
+                    $sha256_hash = $sha256_parts[0];
+                    $sha256_html = '<span class="sha256-toggle">' .
+                                   '<a href="#" class="sha256-btn" onclick="toggleSha256(this);return false;" title="' . _('Show SHA256 checksum') . '">SHA256</a>' .
+                                   '<code class="sha256-hash">' . htmlspecialchars($sha256_hash) . '</code>' .
+                                   '</span>';
+                }
+            }
+
+            $item = $item_link . $sha256_html . '<span class="fileinfo">' .
                     '<span class="filetime" data-isotime="' . $datetime8601 . '">' . $datetime .
                     '</span><span class="filesize">' . $filesize . '</span>' .
                     '<span class="filetime" data-isotime="' . $exdatetime8601 . '">' . $exdatetime . '</span>' .

--- a/tpl/index.tpl.html
+++ b/tpl/index.tpl.html
@@ -200,6 +200,39 @@ footer a {
   display: inline-block;
 }
 
+.sha256-toggle {
+  margin-left: 0.6em;
+  font-size: 0.85em;
+}
+.sha256-btn {
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 0.8em;
+  padding: 1px 5px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #f5f5f5;
+  color: #555;
+  vertical-align: middle;
+}
+.sha256-btn:hover {
+  background: #e8e8e8;
+  color: #333;
+}
+.sha256-hash {
+  display: none;
+  margin-left: 0.4em;
+  font-size: 0.85em;
+  color: #555;
+  word-break: break-all;
+  user-select: all;
+  vertical-align: middle;
+}
+.sha256-hash.visible {
+  display: inline;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     filter: invert(1) hue-rotate(.5turn);
@@ -259,6 +292,16 @@ footer a {
   {L_FOOTER_LINKS}
 </footer>
 
+<script>
+function toggleSha256(btn) {
+  var hashEl = btn.parentNode.querySelector('.sha256-hash');
+  if (hashEl.classList.contains('visible')) {
+    hashEl.classList.remove('visible');
+  } else {
+    hashEl.classList.add('visible');
+  }
+}
+</script>
 <script src="{SITE_URL}tpl/js/js.cookie.js"></script>
 <script src="{SITE_URL}tpl/js/jquery-3.4.1.slim.min.js"></script>
 <script>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Instead of rejecting artifact ZIPs with >1 file, identify `.sha256` files as companions
- Extract both the main artifact and companion checksums
- Store companion files alongside the main artifact in the snapshot directory
- Still reject ZIPs with multiple main (non-companion) files

#### Motivation for adding to Mudlet
Since Mudlet PR Mudlet/Mudlet#9127, the Windows PTB artifact includes a `.sha256` checksum alongside the `.exe` installer. The strict `numFiles > 1` check in `github_artifact.php` silently rejects these 2-file ZIPs, causing PTB artifacts to never appear in the JSON feed. This has broken Windows PTB registration since April 5.

#### Other info (issues closed, discussion etc)
The `.sha256` companion files are needed for the upcoming GitHub Releases-based updater (Mudlet/Mudlet#9125) as a fallback verification source.

**Test case:** After deploying, trigger a PTB build and verify the Windows installer appears in the JSON feed at `json.php?commitid=<sha>` with the `.sha256` file accessible alongside it.